### PR TITLE
#86 / fix chat header

### DIFF
--- a/src/components/ItemCard/GoChat.tsx
+++ b/src/components/ItemCard/GoChat.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import {constantString} from '../../modules/strings';
+import { useDispatch } from 'react-redux';
+import { HeaderHandler } from '../../redux/modules/HeaderState';
 
 interface Props extends RouteComponentProps{
   itemId: number,
@@ -8,11 +10,16 @@ interface Props extends RouteComponentProps{
 }
 
 const GoChat: React.FC<Props> = ({ history, itemId, title }) => {
-
-  const goChat = () => history.push('/ko/mypage/chat', {
-    itemId, //room
-    title
-  });
+  
+  const dispatch = useDispatch();
+  
+  const goChat = () => {
+    history.push('/ko/mypage/chat', {
+      itemId, //room
+      title
+    });
+    dispatch(HeaderHandler(true));
+  };
 
   return (
     <button className='chat-btn' onClick={goChat}>{constantString.goChat}</button>


### PR DESCRIPTION
채팅하기 버튼을 누르면 헤더를 search 헤더로 고정시키는 방법입니다.

![image](https://user-images.githubusercontent.com/72782088/114589937-20561400-9cc3-11eb-8108-0dcd7c2bb12c.png)
